### PR TITLE
feat: emails sent when crud apis

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ public/
 package-lock.json
 composer.lock
 /storage
+/resources/views/mail/

--- a/app/Mail/ApiKeyCreated.php
+++ b/app/Mail/ApiKeyCreated.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ApiKeyCreated extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public string $label,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'New Api key added',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.api.created',
+            text: 'mail.api.created-text',
+            with: [
+                'label' => $this->label,
+            ],
+        );
+    }
+}

--- a/app/Mail/ApiKeyDestroyed.php
+++ b/app/Mail/ApiKeyDestroyed.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class ApiKeyDestroyed extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public string $label,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: 'Api key removed',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: 'mail.api.destroyed',
+            text: 'mail.api.destroyed-text',
+            with: [
+                'label' => $this->label,
+            ],
+        );
+    }
+}

--- a/resources/views/mail/api/created-text.blade.php
+++ b/resources/views/mail/api/created-text.blade.php
@@ -1,0 +1,5 @@
+New API key created
+
+A personal API key with the label {{ $label }} has been created on {{ config('app.name') }}.
+
+If you did not authorize this action, please contact support.

--- a/resources/views/mail/api/created.blade.php
+++ b/resources/views/mail/api/created.blade.php
@@ -1,0 +1,7 @@
+<x-mail::message>
+  # New API key created
+
+  A personal API key with the label {{ $label }} has been created on {{ config('app.name') }}.
+
+  <x-mail::panel>If you did not authorize this action, please contact support.</x-mail::panel>
+</x-mail::message>

--- a/resources/views/mail/api/destroyed-text.blade.php
+++ b/resources/views/mail/api/destroyed-text.blade.php
@@ -1,0 +1,5 @@
+API key removed
+
+A personal API key with the label {{ $label }} has been removed on {{ config('app.name') }}.
+
+If you did not authorize this action, please contact support.

--- a/resources/views/mail/api/destroyed.blade.php
+++ b/resources/views/mail/api/destroyed.blade.php
@@ -1,0 +1,7 @@
+<x-mail::message>
+  # API key removed
+
+  A personal API key with the label {{ $label }} has been removed on {{ config('app.name') }}.
+
+  <x-mail::panel>If you did not authorize this action, please contact support.</x-mail::panel>
+</x-mail::message>

--- a/tests/Unit/Services/CreateApiKeyTest.php
+++ b/tests/Unit/Services/CreateApiKeyTest.php
@@ -6,9 +6,11 @@ namespace Tests\Unit\Services;
 
 use App\Jobs\LogUserAction;
 use App\Jobs\UpdateUserLastActivityDate;
+use App\Mail\ApiKeyCreated;
 use App\Models\User;
 use App\Services\CreateApiKey;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -21,22 +23,10 @@ class CreateApiKeyTest extends TestCase
     public function it_creates_an_api_key(): void
     {
         Queue::fake();
+        Mail::fake();
 
         $user = User::factory()->create();
 
-        $this->executeService($user);
-
-        Queue::assertPushed(UpdateUserLastActivityDate::class, function (UpdateUserLastActivityDate $job) use ($user): bool {
-            return $job->user->id === $user->id;
-        });
-
-        Queue::assertPushed(LogUserAction::class, function (LogUserAction $job) use ($user): bool {
-            return $job->action === 'api_key_creation' && $job->user->id === $user->id;
-        });
-    }
-
-    private function executeService(User $user): void
-    {
         (new CreateApiKey(
             user: $user,
             label: 'Test API Key',
@@ -47,5 +37,17 @@ class CreateApiKeyTest extends TestCase
             'tokenable_id' => $user->id,
             'tokenable_type' => User::class,
         ]);
+
+        Queue::assertPushed(UpdateUserLastActivityDate::class, function (UpdateUserLastActivityDate $job) use ($user): bool {
+            return $job->user->id === $user->id;
+        });
+
+        Queue::assertPushed(LogUserAction::class, function (LogUserAction $job) use ($user): bool {
+            return $job->action === 'api_key_creation' && $job->user->id === $user->id;
+        });
+
+        Mail::assertQueued(ApiKeyCreated::class, function (ApiKeyCreated $job): bool {
+            return $job->label === 'Test API Key';
+        });
     }
 }


### PR DESCRIPTION
This pull request introduces a feature to send email notifications when an API key is created or destroyed. The changes include the addition of new mail classes, updates to the service classes to trigger these emails, and corresponding updates to the tests.

### Email Notification Feature:

* **New Mail Classes**:
  * [`app/Mail/ApiKeyCreated.php`](diffhunk://#diff-10bec16f145669051dc353a4f4cac2c7b8344613af9fcd0910cae47cd4ce9b5aR1-R38): Added a new mail class for API key creation notifications.
  * [`app/Mail/ApiKeyDestroyed.php`](diffhunk://#diff-b1749b96b9087511403b5ee6806cbcc465c5a2fd67f436cae9cea595908730a6R1-R38): Added a new mail class for API key deletion notifications.

* **Service Class Updates**:
  * [`app/Services/CreateApiKey.php`](diffhunk://#diff-c2b6e5b32b69d7dfeab9cc73a4ac0f2706e8a015dd7bc015e3681cf3ec6eb73cR9-R11): Modified to send an email when an API key is created. [[1]](diffhunk://#diff-c2b6e5b32b69d7dfeab9cc73a4ac0f2706e8a015dd7bc015e3681cf3ec6eb73cR9-R11) [[2]](diffhunk://#diff-c2b6e5b32b69d7dfeab9cc73a4ac0f2706e8a015dd7bc015e3681cf3ec6eb73cR25-R30) [[3]](diffhunk://#diff-c2b6e5b32b69d7dfeab9cc73a4ac0f2706e8a015dd7bc015e3681cf3ec6eb73cR46-R51)
  * [`app/Services/DestroyApiKey.php`](diffhunk://#diff-4872947a50a2a6cffc872c2fb891c1b2221597c1919dddff98019cd9f7e9cda6R9-R11): Modified to send an email when an API key is destroyed. [[1]](diffhunk://#diff-4872947a50a2a6cffc872c2fb891c1b2221597c1919dddff98019cd9f7e9cda6R9-R11) [[2]](diffhunk://#diff-4872947a50a2a6cffc872c2fb891c1b2221597c1919dddff98019cd9f7e9cda6L23-R31) [[3]](diffhunk://#diff-4872947a50a2a6cffc872c2fb891c1b2221597c1919dddff98019cd9f7e9cda6R47-R52)

* **Email Templates**:
  * [`resources/views/mail/api/created.blade.php`](diffhunk://#diff-fba02d52791a06d0af604717706cf2ec4b40dd81751933ebccfd580f9dde7395R1-R7): Added a new Blade template for API key creation emails.
  * [`resources/views/mail/api/created-text.blade.php`](diffhunk://#diff-e35f692e8f7df26e4b55655cb5184d1ac8106e4b02dce4cbcb0dfe42ba0c4dcaR1-R5): Added a plain text template for API key creation emails.
  * [`resources/views/mail/api/destroyed.blade.php`](diffhunk://#diff-32775ddee2a4397a5c503f4c5a8ac5281514ac9017869e256f4ca91bed5f57adR1-R7): Added a new Blade template for API key deletion emails.
  * [`resources/views/mail/api/destroyed-text.blade.php`](diffhunk://#diff-fc5034b26b1738a46cdacb1a085d7e3a313bf707a0f8a654ec37a2b9dfbf6970R1-R5): Added a plain text template for API key deletion emails.

* **Test Updates**:
  * [`tests/Unit/Services/CreateApiKeyTest.php`](diffhunk://#diff-a4f515b62b4a2e51709f40510be4d816f31b9215419e977020c070c7fccc0aa9R9-R13): Updated to include assertions for the new email notifications. [[1]](diffhunk://#diff-a4f515b62b4a2e51709f40510be4d816f31b9215419e977020c070c7fccc0aa9R9-R13) [[2]](diffhunk://#diff-a4f515b62b4a2e51709f40510be4d816f31b9215419e977020c070c7fccc0aa9R26-L39) [[3]](diffhunk://#diff-a4f515b62b4a2e51709f40510be4d816f31b9215419e977020c070c7fccc0aa9R40-R51)
  * [`tests/Unit/Services/DestroyApiKeyTest.php`](diffhunk://#diff-80e83ba7a9bb65f09b6913baebf34b947f5d00c36f285f63ee9265c6e1a8575bR9-R13): Updated to include assertions for the new email notifications. [[1]](diffhunk://#diff-80e83ba7a9bb65f09b6913baebf34b947f5d00c36f285f63ee9265c6e1a8575bR9-R13) [[2]](diffhunk://#diff-80e83ba7a9bb65f09b6913baebf34b947f5d00c36f285f63ee9265c6e1a8575bR26-R40) [[3]](diffhunk://#diff-80e83ba7a9bb65f09b6913baebf34b947f5d00c36f285f63ee9265c6e1a8575bL39-R52)

Additionally, the `.prettierignore` file was updated to include the new mail view directory.

* **Prettier Ignore Update**:
  * [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R12): Added `/resources/views/mail/` to the ignore list.