### PR TITLE
fix: remove duplicate registration of telescope

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,6 @@ class AppServiceProvider extends ServiceProvider
     {
         if ($this->app->environment('local') && class_exists(TelescopeServiceProvider::class)) {
             $this->app->register(TelescopeServiceProvider::class);
-            $this->app->register(TelescopeServiceProvider::class);
         }
     }
 


### PR DESCRIPTION
Removing the duplicate registration of the `TelescopeServiceProvider` improves code clarity and prevents unnecessary processing during the application bootstrapping. This change ensures that the service provider is registered only once, which can enhance performance and reduce potential conflicts.